### PR TITLE
Allow using formlists as filters

### DIFF
--- a/include/Cache.h
+++ b/include/Cache.h
@@ -32,7 +32,7 @@ namespace Cache
 
 	namespace FormType
 	{
-		inline constexpr frozen::set<RE::FormType, 18> set{
+		inline constexpr frozen::set<RE::FormType, 19> set{
 			//types
 			RE::FormType::Armor,
 			RE::FormType::Weapon,
@@ -52,7 +52,8 @@ namespace Cache
 			RE::FormType::MusicType,
 			RE::FormType::Faction,
 			RE::FormType::Spell,
-			RE::FormType::Projectile
+			RE::FormType::Projectile,
+			RE::FormType::FormList
 		};
 
 		bool IsFilter(RE::FormType a_type);

--- a/include/Distribute.h
+++ b/include/Distribute.h
@@ -97,6 +97,11 @@ namespace Filter
 						const auto keywordForm = a_item->As<RE::BGSKeywordForm>();
 						return keywordForm && keywordForm->HasKeywordID(a_filter->GetFormID());
 					}
+				case RE::FormType::FormList:
+					{
+						const auto listForm = a_filter->As<RE::BGSListForm>();
+						return listForm && listForm->HasForm(a_item);
+					}
 				default:
 					return false;
 				}


### PR DESCRIPTION
Allows to assign keywords to all formlist items at once instead of listing items one by one.